### PR TITLE
Update Dependencies and Fix Audio Channel Close

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
 		<dependency>
 			<groupId>net.dv8tion</groupId>
 			<artifactId>JDA</artifactId>
-			<version>3.3.1_303</version>
+			<version>3.3.1_305</version>
 			<type>jar</type>
 			<scope>compile</scope>
 		</dependency>
@@ -166,26 +166,26 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>22.0</version>
+			<version>23.4-jre</version>
 		</dependency>
 		<!-- https://mvnrepository.com/artifact/com.google.apis/google-api-services-youtube -->
 		<dependency>
 			<groupId>com.google.apis</groupId>
 			<artifactId>google-api-services-youtube</artifactId>
-			<version>v3-rev183-1.22.0</version>
+			<version>v3-rev187-1.23.0</version>
 		</dependency>
 		<!-- http://mvnrepository.com/artifact/org.xerial/sqlite-jdbc -->
 		<dependency>
 			<groupId>org.xerial</groupId>
 			<artifactId>sqlite-jdbc</artifactId>
-			<version>3.18.0</version>
+			<version>3.21.0</version>
 		</dependency>
 		<!-- These dependencies are required by JDA but are not in compile scope -->
 		<!-- https://mvnrepository.com/artifact/org.apache.commons/commons-lang3 -->
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
-			<version>3.6</version>
+			<version>3.7</version>
 		</dependency>
 		<!-- https://mvnrepository.com/artifact/org.apache.commons/commons-collections4 -->
 		<dependency>
@@ -197,13 +197,13 @@
 		<dependency>
 			<groupId>org.json</groupId>
 			<artifactId>json</artifactId>
-			<version>20160810</version>
+			<version>20171018</version>
 		</dependency>
 		<!-- https://mvnrepository.com/artifact/net.java.dev.jna/jna -->
 		<dependency>
 			<groupId>net.java.dev.jna</groupId>
 			<artifactId>jna</artifactId>
-			<version>4.4.0</version>
+			<version>4.5.0</version>
 		</dependency>
 		<!-- https://mvnrepository.com/artifact/com.neovisionaries/nv-websocket-client -->
 		<dependency>
@@ -221,28 +221,28 @@
 		<dependency>
 			<groupId>org.jsoup</groupId>
 			<artifactId>jsoup</artifactId>
-			<version>1.10.3</version>
+			<version>1.11.2</version>
 		</dependency>
 		<dependency>
 			<groupId>com.sparkjava</groupId>
 			<artifactId>spark-core</artifactId>
-			<version>2.5.4</version>
+			<version>2.7.1</version>
 		</dependency>
 		<dependency>
 			<groupId>com.sparkjava</groupId>
 			<artifactId>spark-template-freemarker</artifactId>
-			<version>2.3</version>
+			<version>2.7.1</version>
 		</dependency>
 		<!-- https://mvnrepository.com/artifact/org.freemarker/freemarker -->
 		<dependency>
 			<groupId>org.freemarker</groupId>
 			<artifactId>freemarker</artifactId>
-			<version>2.3.25-incubating</version>
+			<version>2.3.27-incubating</version>
 		</dependency>
 		<dependency>
 			<groupId>org.java-websocket</groupId>
 			<artifactId>Java-WebSocket</artifactId>
-			<version>1.3.4</version>
+			<version>1.3.6</version>
 		</dependency>
 	</dependencies>
 	<url>https://momobot.io</url>

--- a/src/io/ph/bot/audio/GuildTrackManager.java
+++ b/src/io/ph/bot/audio/GuildTrackManager.java
@@ -69,7 +69,7 @@ public class GuildTrackManager extends AudioEventAdapter {
 		if (!queue.isEmpty()) {
 			// Kill queue and leave channel if no one is in
 			if (guild.getAudioManager().getConnectedChannel().getMembers().size() == 1) {
-				guild.getAudioManager().closeAudioConnection();
+				new Thread(() -> guild.getAudioManager().closeAudioConnection()).start();
 				g.getMusicManager().reset();
 				return;
 			}
@@ -85,7 +85,7 @@ public class GuildTrackManager extends AudioEventAdapter {
 				ch.sendMessage(em.build()).queue();
 			}
 			currentSong = null;
-			guild.getAudioManager().closeAudioConnection();
+			new Thread(() -> guild.getAudioManager().closeAudioConnection()).start();
 		}
 	}
 


### PR DESCRIPTION
 * According to https://github.com/DV8FromTheWorld/JDA/issues/485#issuecomment-332559873
   audio connections cannot be closed in the same thread that is handling the event.
   guild.getAudioManager().closeAudioConnection() is now run on it's own thread.

 * Updated dependencies to the latest version with exception of slf4j